### PR TITLE
[BREAKING CHANGE] Generic PubSub interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,35 +10,38 @@ _NOTE_: Today, only [Google Cloud PubSub](https://cloud.google.com/pubsub/docs/o
 npm install --save @algoan/pubsub
 ```
 
-## Setup for simulator
+## Usage
 
-You need to have a google account and have installed gcloud sdk.
+### Google Cloud PubSub
 
-Then, you need to install the simulator with:
+#### Run tests
+
+To run tests or to try the PubSubFactory class, you need to have a google account and have installed gcloud sdk.
+
+Then, to install the [Google PubSub simulator](https://cloud.google.com/pubsub/docs/emulator), run:
 
 ```shell
 gcloud components install pubsub-emulator
 gcloud components update
 ```
 
-## Launch the tests
-
-Start the tests in another terminal with:
+Start tests running:
 
 ```shell
 npm test
 ```
 
-It will launch a Google PubSub emulator
+It will launch a Google PubSub emulator thanks to the [google-pubsub-emulator](https://github.com/ert78gb/google-pubsub-emulator) library.
 
-## Usage
+
+#### Example
 
 To create a PubSub instance using Google Cloud:
 
 ```typescript
-import { ExtendedMessage, PubSub, PubSubFactory, Transport } from '@algoan/pubsub'
+import { EmittedMessage, GCPubSub, PubSubFactory, Transport } from '@algoan/pubsub'
 
-const pubSub: PubSub = PubSubFactory.create({
+const pubSub: GCPubSub = PubSubFactory.create({
   transport: Transport.GOOGLE_PUBSUB,
   options: {
     projectId: 'test',
@@ -49,7 +52,7 @@ const topicName: string = 'some_topic';
 
 await pubsub.listen(topicName, {
   autoAck: true,
-  onMessage: (data: ExtendedMessage<{foo: string}>) => {
+  onMessage: (data: EmittedMessage<{foo: string}>) => {
     console.log(data.parsedData); // { foo: 'bar', time: {Date.now}, _eventName: 'some_topic' }
     // do whatever you want. The message has already been acknowledged
   },
@@ -80,27 +83,34 @@ The only static method from the `PubSubFactory` class. It initiates a new PubSub
   - `namespace`: Add a namespace property to [Message attributes](https://googleapis.dev/nodejs/pubsub/latest/google.pubsub.v1.html#.PubsubMessage) when publishing on a topic.
   - `environment`: Add a environment property to [Message attributes](https://googleapis.dev/nodejs/pubsub/latest/google.pubsub.v1.html#.PubsubMessage) when publishing on a topic.
 
-### `pubsub.listen(event, options)`
+### `pubsub.listen(event, opts)`
 
 Listen to a specific event.
 
 _NOTE_: It only uses the [Google Cloud subscription pull](https://cloud.google.com/pubsub/docs/pull) delivery for now.
 
 - `event`: Name of the event.
-- `options`: Options related to the Listener method
+- `opts`: Options related to the Listener method
   - `onMessage`: Method called when receiving a message
   - `onError`: Method called when an error occurs
-  - `autoAck`: Automatically ACK an event as soon as it is received (default to `true`)
-  - `subscriptionOptions`: Options applied to the subscription (have a look at [Subscription options](https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#get))
-  - `topicOptions`: Options applied to the created topic (have a look at [Topic options](https://googleapis.dev/nodejs/pubsub/latest/Topic.html#get))
+  - `options`: Option related to the chosen transport
 
-### `pubsub.emit(event, payload, options)`
+If the chosen transport is Google Cloud PubSub, then `options` would be:
+
+- `autoAck`: Automatically ACK an event as soon as it is received (default to `true`)
+- `subscriptionOptions`: Options applied to the subscription (have a look at [Subscription options](https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#get))
+- `topicOptions`: Options applied to the created topic (have a look at [Topic options](https://googleapis.dev/nodejs/pubsub/latest/Topic.html#get))
+
+### `pubsub.emit(event, payload, opts)`
 
 Emit a specific event with a payload. It added attributes in the message if you have added a namespace or an environment when setting the `PubSubFactory` class. It also adds an `_eventName` and a `time` property in the emitted `payload`.
 
 - `event`: Name of the event to emit.
 - `payload`: Payload to send. It will be buffered by Google, and then parsed by the [listen](#pubsublistenevent-options) method.
-- `options`: Options related to the Emit method
-  - `customAttributes`: Add custom attributes which will be stored in the `message.attributes` property.
-  - `subscriptionOptions`: Options applied to the subscription (have a look at [Subscription options](https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#get))
-  - `topicOptions`: Options applied to the created topic (have a look at [Topic options](https://googleapis.dev/nodejs/pubsub/latest/Topic.html#get))
+- `opts`: Options related to the Emit method
+  - `metadata`: Custom metadata added to the message
+  - `options`: Option related to the chosen transport
+
+If the chosen transport is Google Cloud PubSub, then `options` would be:
+
+- `topicOptions`: Options applied to the created topic (have a look at [Topic options](https://googleapis.dev/nodejs/pubsub/latest/Topic.html#get))

--- a/src/EmittedMessage.ts
+++ b/src/EmittedMessage.ts
@@ -1,0 +1,31 @@
+/**
+ * Message emitted by the PubSub
+ */
+export interface EmittedMessage<T> {
+  /** Message unique identifier */
+  id: string;
+  /** Payload sent */
+  payload: T;
+  /** Metadata: namespace, environment etc */
+  metadata?: Metadata;
+  /** Acknowledgment unique identifier */
+  ackId?: string;
+  /** Counter, if message are ordered */
+  count?: number;
+  /** Date of emission */
+  emittedAt: Date;
+  /** Date of reception */
+  receivedAt: Date;
+  /** Duration in ms */
+  duration: number;
+}
+
+/**
+ * Payload metadata
+ */
+export interface Metadata {
+  namespace?: string;
+  environment?: string;
+  // tslint:disable-next-line: no-any
+  [key: string]: any;
+}

--- a/src/GoogleCloudPubSub/ExtendedMessage.ts
+++ b/src/GoogleCloudPubSub/ExtendedMessage.ts
@@ -1,24 +1,37 @@
-import { Message } from '@google-cloud/pubsub';
-import { Payload } from './lib';
+import { Attributes, Message } from '@google-cloud/pubsub';
 
-export type ExtendedPayload<T> = T & Payload;
+import { EmittedMessage } from '..';
+
 /**
  * Extends the Google PubSub message class by adding a parsed data getter
  */
-export class ExtendedMessage<T> {
-  /**
-   * Message's data buffer parsed
-   */
-  public readonly parsedData: ExtendedPayload<T>;
-
-  /**
-   * Base message
-   */
-  public readonly message: Message;
+export class ExtendedMessage<T> implements EmittedMessage<T> {
+  /** Message unique identifier */
+  public id: string;
+  /** Payload sent */
+  public payload: T;
+  /** Metadata: namespace, environment etc */
+  public metadata?: Attributes;
+  /** Acknowledgment unique identifier */
+  public ackId?: string;
+  /** Counter, if message are ordered */
+  public count?: number;
+  /** Date of emission */
+  public emittedAt: Date;
+  /** Date of reception */
+  public receivedAt: Date;
+  /** Duration in ms */
+  public duration: number;
 
   constructor(message: Message) {
+    this.id = message.id;
     // tslint:disable-next-line: no-unsafe-any
-    this.parsedData = JSON.parse(message.data.toString());
-    this.message = message;
+    this.payload = JSON.parse(message.data.toString());
+    this.metadata = message.attributes;
+    this.ackId = message.ackId;
+    this.count = isNaN(Number(message.orderingKey)) ? undefined : Number(message.orderingKey);
+    this.emittedAt = message.publishTime;
+    this.receivedAt = new Date(message.received);
+    this.duration = message.received - this.emittedAt.valueOf();
   }
 }

--- a/src/GoogleCloudPubSub/lib.ts
+++ b/src/GoogleCloudPubSub/lib.ts
@@ -1,6 +1,7 @@
-import { Attributes, GetSubscriptionOptions, GetTopicOptions, Subscription, Topic } from '@google-cloud/pubsub';
+import { GetSubscriptionOptions, GetTopicOptions, PubSub as GPubSub, Subscription, Topic } from '@google-cloud/pubsub';
 import { ClientConfig } from '@google-cloud/pubsub/build/src/pubsub';
-import { ExtendedMessage } from './ExtendedMessage';
+
+import { PubSub } from '..';
 
 /**
  * Extends Google PubSub config
@@ -24,35 +25,18 @@ export type TopicMap = Map<string, Topic>;
 export type SubscriptionMap = Map<string, Subscription>;
 
 /**
- * Options used both in emit and listen methods
+ * PubSub SDK for Google Cloud
  */
-interface Options {
-  subscriptionOptions?: Omit<GetSubscriptionOptions, 'autoCreate'>;
-  topicOptions?: Omit<GetTopicOptions, 'autoCreate'>;
-}
+export type GCPubSub = PubSub<GPubSub, Subscription, GCListenOptions>;
 
 /**
- * Listen options argument
+ * Google Cloud PubSub Listen options
  */
-export interface ListenOptions<T> extends Options {
+export interface GCListenOptions {
+  /** Automatic Acknowledgment */
   autoAck?: boolean;
-  /** Error handler */
-  onError?(error: Error): void;
-  /** Message handler */
-  onMessage?(extendedMessage: ExtendedMessage<T>): void;
-}
-
-/**
- * Emit options argument
- */
-export interface EmitOptions extends Options {
-  customAttributes?: Attributes;
-}
-
-/**
- * Payload in the emitted message
- */
-export interface Payload {
-  _eventName: string;
-  time: number;
+  /** Google PubSub subscription options */
+  subscriptionOptions?: Omit<GetSubscriptionOptions, 'autoCreate'>;
+  /** Google PubSub topic options */
+  topicOptions?: Omit<GetTopicOptions, 'autoCreate'>;
 }

--- a/src/PubSub.ts
+++ b/src/PubSub.ts
@@ -1,22 +1,53 @@
-import { PubSub as GPubSub } from '@google-cloud/pubsub';
-import { EmitOptions, ListenOptions } from './GoogleCloudPubSub';
+import { EmittedMessage, Metadata } from './EmittedMessage';
 
 /**
  * PubSub generic interface
  */
-export interface PubSub {
-  client: GPubSub;
-
+export interface PubSub<PSClient, PSSubscription, SubscriptionOptions> {
+  /**
+   * The exposed PubSub client
+   * If it is Google, then PSClient = PubSub
+   * https://github.com/googleapis/nodejs-pubsub/blob/master/src/pubsub.ts#L235
+   */
+  client: PSClient;
+  /**
+   * Exposed cached subscriptions
+   * If it is Google, then PSSubscription = Subscription
+   * https://github.com/googleapis/nodejs-pubsub/blob/master/src/subscription.ts#L211
+   */
+  subscriptions: Map<string, PSSubscription>;
   /**
    * Listen to a subscription
    * @param event Event to listen to
-   * @param handlers Message handler
+   * @param options Message handler
    */
-  listen<T>(event: string, options?: ListenOptions<T>): Promise<void>;
+  listen<MessagePayload>(event: string, options?: ListenOptions<MessagePayload, SubscriptionOptions>): Promise<void>;
 
   /**
    * Emit an event
    * @param event Event to emit
+   * @param data Payload to send
+   * @param options Options related to the emit options
    */
-  emit<T>(event: string, data: T, options?: EmitOptions): Promise<string>;
+  emit(event: string, data: object, options?: EmitOptions<SubscriptionOptions>): Promise<string>;
+}
+
+/**
+ * Listen options argument
+ */
+export interface ListenOptions<T, Options> {
+  /** Error handler */
+  onError?(error: Error): void;
+  /** Message handler */
+  onMessage?(extendedMessage: EmittedMessage<T>): void;
+  /** Options */
+  options?: Options;
+}
+
+/**
+ * Emit options argument
+ */
+export interface EmitOptions<Options> {
+  metadata?: Metadata;
+  options?: Options;
 }

--- a/src/PubSubFactory.ts
+++ b/src/PubSubFactory.ts
@@ -1,5 +1,4 @@
-import { GoogleCloudPubSub, GooglePubSubOptions } from './GoogleCloudPubSub';
-import { PubSub } from './PubSub';
+import { GCPubSub, GoogleCloudPubSub, GooglePubSubOptions } from './GoogleCloudPubSub';
 
 /**
  * PubSub factory class
@@ -10,7 +9,7 @@ export class PubSubFactory {
    * Create a pubsub instance depending of the transport
    * @param params PubSub parameters
    */
-  public static create(params: FactoryParameters = { transport: Transport.GOOGLE_PUBSUB }): PubSub {
+  public static create(params: FactoryParameters = { transport: Transport.GOOGLE_PUBSUB }): GCPubSub {
     return new GoogleCloudPubSub(params.options);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './PubSubFactory';
 export * from './PubSub';
-export * from './GoogleCloudPubSub';
+export * from './EmittedMessage';
+export * from './GoogleCloudPubSub/lib';


### PR DESCRIPTION
## Description 

The goal of the Pull Request is to transform the `PubSub` interface in order to be generic. Thus, when selecting the `GooglePubSub Transport`, the `PubSubFactory` is able to return the correct types.

I did this because when we'll add a new transport (for instance Redis PubSub), Types would be difficult to maintain. They were specific to Google.

### Features

- Create a new generic message interface which is interpreted by the `onMessage` handler
- Export cached subscriptions from the PubSub class
- Transform the `PubSub` interface in order to be Generic

_NOTE_: commits could be more organized 😬  It could be hard to review, I'm sorry about that...
