### PR TITLE
Customize topic and subscription separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The only static method from the `PubSubFactory` class. It initiates a new PubSub
   - `pinoOptions`: If `debug` is set to true, set the [pino logger options](https://getpino.io/#/docs/api?id=options). Default to `level: debug` and `prettyPrint: true` if `NODE_ENV` is not equal to `production`.
   - `topicsPrefix`: Add a prefix to all created topics. Example: `topicsPrefix: 'my-topic'`, all topics will begin with `my-topic+{your topic name}`.
   - `subscriptionsPrefix`: Add a prefix to all created subscriptions. Example: `subscriptionsPrefix: 'my-sub'`, all topics will begin with `my-sub%{your topic name}`.
+  - `subscriptionsSeparator`: Customize separator between subscriptionsPrefix and topic name. Example: `subscriptionsSeparator: '-'`, all topics will be  `{subscription prefix}-{your topic name} (default to '%')`.
   - `namespace`: Add a namespace property to [Message attributes](https://googleapis.dev/nodejs/pubsub/latest/google.pubsub.v1.html#.PubsubMessage) when publishing on a topic.
   - `environment`: Add a environment property to [Message attributes](https://googleapis.dev/nodejs/pubsub/latest/google.pubsub.v1.html#.PubsubMessage) when publishing on a topic.
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ The only static method from the `PubSubFactory` class. It initiates a new PubSub
   - `debug`: Display logs if it is set to true. It uses a [pino logger](https://getpino.io/#/) and [pino-pretty](https://github.com/pinojs/pino-pretty) if `NODE_ENV` is not equal to `production`.
   - `pinoOptions`: If `debug` is set to true, set the [pino logger options](https://getpino.io/#/docs/api?id=options). Default to `level: debug` and `prettyPrint: true` if `NODE_ENV` is not equal to `production`.
   - `topicsPrefix`: Add a prefix to all created topics. Example: `topicsPrefix: 'my-topic'`, all topics will begin with `my-topic+{your topic name}`.
-  - `subscriptionsPrefix`: Add a prefix to all created subscriptions. Example: `subscriptionsPrefix: 'my-sub'`, all topics will begin with `my-sub%{your topic name}`.
-  - `subscriptionsSeparator`: Customize separator between subscriptionsPrefix and topic name. Example: `subscriptionsSeparator: '-'`, all topics will be  `{subscription prefix}-{your topic name} (default to '%')`.
+  - `topicsSeparator`: Customize separator between topicsPrefix and topic name. Example: `topicsSeparator: '-'`, all topics will be  `{topic prefix}-{your topic name} (default to '+')`.
+  - `subscriptionsPrefix`: Add a prefix to all created subscriptions. Example: `subscriptionsPrefix: 'my-sub'`, all subscriptions will begin with `my-sub%{your topic name}`.
+  - `subscriptionsSeparator`: Customize separator between subscriptionsPrefix and topic name. Example: `subscriptionsSeparator: '-'`, all subscriptions will be  `{subscription prefix}-{your topic name} (default to '%')`.
   - `namespace`: Add a namespace property to [Message attributes](https://googleapis.dev/nodejs/pubsub/latest/google.pubsub.v1.html#.PubsubMessage) when publishing on a topic.
   - `environment`: Add a environment property to [Message attributes](https://googleapis.dev/nodejs/pubsub/latest/google.pubsub.v1.html#.PubsubMessage) when publishing on a topic.
 

--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -12,14 +12,7 @@ import * as Pino from 'pino';
 
 import { EmitOptions, ListenOptions } from '..';
 import { ExtendedMessage } from './ExtendedMessage';
-import {
-  GCListenOptions,
-  GCPubSub,
-  GCSubscriptionOptions,
-  GooglePubSubOptions,
-  SubscriptionMap,
-  TopicMap,
-} from './lib';
+import { GCListenOptions, GCPubSub, GCSubscriptionOptions, GooglePubSubOptions, SubscriptionMap, TopicMap } from './lib';
 
 /**
  * Google PubSub SDK
@@ -41,6 +34,15 @@ export class GoogleCloudPubSub implements GCPubSub {
    * then subscription names will begin with "app%"
    */
   private readonly subscriptionsPrefix?: string;
+
+
+  /**
+   * Subscription separator
+   * Example: if "subscriptionSeparator = -",
+   * then subscription name will begin with "<subscriptionPrefix>-"
+   * @default %
+   */
+  private readonly subscriptionsSeparator?: string;
 
   /**
    * Topic prefix
@@ -71,9 +73,10 @@ export class GoogleCloudPubSub implements GCPubSub {
    */
   private readonly logger: Pino.Logger;
 
-  constructor(options: GooglePubSubOptions = {}) {
+  constructor(options: GooglePubSubOptions = { subscriptionsSeparator: '%'}) {
     this.client = new GPubSub(options);
     this.subscriptionsPrefix = options.subscriptionsPrefix;
+    this.subscriptionsSeparator = options.subscriptionsSeparator;
     this.topicsPrefix = options.topicsPrefix;
     this.namespace = options.namespace;
     this.environment = options.environment;
@@ -239,7 +242,7 @@ export class GoogleCloudPubSub implements GCPubSub {
    */
   private getSubscriptionName(event: string): string {
     if (this.subscriptionsPrefix !== undefined) {
-      return `${this.subscriptionsPrefix}%${event}`;
+      return `${this.subscriptionsPrefix}${this.subscriptionsSeparator}${event}`
     }
 
     return event;

--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -59,6 +59,15 @@ export class GoogleCloudPubSub implements GCPubSub {
   private readonly topicsPrefix?: string;
 
   /**
+   * Topic separator
+   * Example: if "topicsSeparator = -",
+   * then topic names will begin with "<topicsPrefix>-"
+   *
+   * @defaultValue '+'
+   */
+  private readonly topicsSeparator?: string;
+
+  /**
    * An optional namespace
    * Can be useful when emitting an event
    */
@@ -85,6 +94,7 @@ export class GoogleCloudPubSub implements GCPubSub {
     this.subscriptionsPrefix = options.subscriptionsPrefix;
     this.subscriptionsSeparator = options.subscriptionsSeparator !== undefined ? options.subscriptionsSeparator : '%';
     this.topicsPrefix = options.topicsPrefix;
+    this.topicsSeparator = options.topicsSeparator !== undefined ? options.topicsSeparator : '+';
     this.namespace = options.namespace;
     this.environment = options.environment;
     this.topics = new Map();
@@ -237,7 +247,7 @@ export class GoogleCloudPubSub implements GCPubSub {
    */
   private getTopicName(event: string): string {
     if (this.topicsPrefix !== undefined) {
-      return `${this.topicsPrefix}+${event}`;
+      return `${this.topicsPrefix}${this.topicsSeparator}${event}`;
     }
 
     return event;

--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -12,7 +12,14 @@ import * as Pino from 'pino';
 
 import { EmitOptions, ListenOptions } from '..';
 import { ExtendedMessage } from './ExtendedMessage';
-import { GCListenOptions, GCPubSub, GCSubscriptionOptions, GooglePubSubOptions, SubscriptionMap, TopicMap } from './lib';
+import {
+  GCListenOptions,
+  GCPubSub,
+  GCSubscriptionOptions,
+  GooglePubSubOptions,
+  SubscriptionMap,
+  TopicMap,
+} from './lib';
 
 /**
  * Google PubSub SDK
@@ -35,12 +42,12 @@ export class GoogleCloudPubSub implements GCPubSub {
    */
   private readonly subscriptionsPrefix?: string;
 
-
   /**
    * Subscription separator
    * Example: if "subscriptionSeparator = -",
    * then subscription name will begin with "<subscriptionPrefix>-"
-   * @default %
+   *
+   * @defaultValue `%`
    */
   private readonly subscriptionsSeparator?: string;
 
@@ -73,7 +80,7 @@ export class GoogleCloudPubSub implements GCPubSub {
    */
   private readonly logger: Pino.Logger;
 
-  constructor(options: GooglePubSubOptions = { subscriptionsSeparator: '%'}) {
+  constructor(options: GooglePubSubOptions = { subscriptionsSeparator: '%' }) {
     this.client = new GPubSub(options);
     this.subscriptionsPrefix = options.subscriptionsPrefix;
     this.subscriptionsSeparator = options.subscriptionsSeparator;
@@ -242,7 +249,7 @@ export class GoogleCloudPubSub implements GCPubSub {
    */
   private getSubscriptionName(event: string): string {
     if (this.subscriptionsPrefix !== undefined) {
-      return `${this.subscriptionsPrefix}${this.subscriptionsSeparator}${event}`
+      return `${this.subscriptionsPrefix}${this.subscriptionsSeparator}${event}`;
     }
 
     return event;

--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -80,10 +80,10 @@ export class GoogleCloudPubSub implements GCPubSub {
    */
   private readonly logger: Pino.Logger;
 
-  constructor(options: GooglePubSubOptions = { subscriptionsSeparator: '%' }) {
+  constructor(options: GooglePubSubOptions = {}) {
     this.client = new GPubSub(options);
     this.subscriptionsPrefix = options.subscriptionsPrefix;
-    this.subscriptionsSeparator = options.subscriptionsSeparator;
+    this.subscriptionsSeparator = options.subscriptionsSeparator !== undefined ? options.subscriptionsSeparator : '%';
     this.topicsPrefix = options.topicsPrefix;
     this.namespace = options.namespace;
     this.environment = options.environment;

--- a/src/GoogleCloudPubSub/lib.ts
+++ b/src/GoogleCloudPubSub/lib.ts
@@ -17,6 +17,7 @@ import { PubSub } from '..';
 export interface GooglePubSubOptions extends ClientConfig {
   topicsPrefix?: string;
   subscriptionsPrefix?: string;
+  subscriptionsSeparator?: string;
   namespace?: string;
   environment?: string;
   debug?: boolean;

--- a/src/GoogleCloudPubSub/lib.ts
+++ b/src/GoogleCloudPubSub/lib.ts
@@ -16,6 +16,7 @@ import { PubSub } from '..';
  */
 export interface GooglePubSubOptions extends ClientConfig {
   topicsPrefix?: string;
+  topicsSeparator?: string;
   subscriptionsPrefix?: string;
   subscriptionsSeparator?: string;
   namespace?: string;

--- a/test/GoogleCloudPubSub.test.ts
+++ b/test/GoogleCloudPubSub.test.ts
@@ -213,7 +213,7 @@ test('GPS004 - should not add prefix to subscription and topic', async (t: Execu
 });
 
 test('GPS005 - should add separator to subscription and topic', async (t: ExecutionContext): Promise<void> => {
-  const topicName: string = 'topic_1';
+  const topicName: string = 'topic_3';
   const pubsub: GCPubSub = PubSubFactory.create({
     transport: Transport.GOOGLE_PUBSUB,
     options: {
@@ -234,7 +234,7 @@ test('GPS005 - should add separator to subscription and topic', async (t: Execut
 });
 
 test('GPS006 - should not add separator to subscription and topic', async (t: ExecutionContext): Promise<void> => {
-  const topicName: string = 'topic_1';
+  const topicName: string = 'topic_4';
   const pubsub: GCPubSub = PubSubFactory.create({
     transport: Transport.GOOGLE_PUBSUB,
     options: {

--- a/test/GoogleCloudPubSub.test.ts
+++ b/test/GoogleCloudPubSub.test.ts
@@ -220,7 +220,7 @@ test('GPS005 - should add separator to subscription and topic', async (t: Execut
       projectId,
       topicsPrefix: 'algoan',
       subscriptionsPrefix: 'test-app',
-      subscriptionsSeparator: '-'
+      subscriptionsSeparator: '-',
     },
   });
 

--- a/test/GoogleCloudPubSub.test.ts
+++ b/test/GoogleCloudPubSub.test.ts
@@ -2,7 +2,8 @@
 /* eslint-disable no-void */
 import test, { CbExecutionContext, ExecutionContext } from 'ava';
 import * as sinon from 'sinon';
-import { isPayloadError, EmittedMessage, GCPubSub, PubSubFactory, Transport } from '../src';
+
+import { EmittedMessage, GCPubSub, isPayloadError, PubSubFactory, Transport } from '../src';
 
 const Emulator = require('google-pubsub-emulator');
 
@@ -209,4 +210,45 @@ test('GPS004 - should not add prefix to subscription and topic', async (t: Execu
   t.false(isSubcriptionExisting);
   t.true(isTopicExistingWithoutPrefix);
   t.true(isSubcriptionExistingWithoutPrefix);
+});
+
+test('GPS005 - should add separator to subscription and topic', async (t: ExecutionContext): Promise<void> => {
+  const topicName: string = 'topic_1';
+  const pubsub: GCPubSub = PubSubFactory.create({
+    transport: Transport.GOOGLE_PUBSUB,
+    options: {
+      projectId,
+      topicsPrefix: 'algoan',
+      subscriptionsPrefix: 'test-app',
+      subscriptionsSeparator: '-'
+    },
+  });
+
+  await pubsub.listen(topicName);
+
+  const [isTopicExisting] = await pubsub.client.topic(`algoan+${topicName}`).exists();
+  const [isSubcriptionExisting] = await pubsub.client.subscription(`test-app-${topicName}`).exists();
+
+  t.true(isTopicExisting);
+  t.true(isSubcriptionExisting);
+});
+
+test('GPS006 - should not add separator to subscription and topic', async (t: ExecutionContext): Promise<void> => {
+  const topicName: string = 'topic_1';
+  const pubsub: GCPubSub = PubSubFactory.create({
+    transport: Transport.GOOGLE_PUBSUB,
+    options: {
+      projectId,
+      topicsPrefix: 'algoan',
+      subscriptionsPrefix: 'test-app',
+    },
+  });
+
+  await pubsub.listen(topicName);
+
+  const [isTopicExisting] = await pubsub.client.topic(`algoan+${topicName}`).exists();
+  const [isSubcriptionExisting] = await pubsub.client.subscription(`test-app%${topicName}`).exists();
+
+  t.true(isTopicExisting);
+  t.true(isSubcriptionExisting);
 });

--- a/test/GoogleCloudPubSub.test.ts
+++ b/test/GoogleCloudPubSub.test.ts
@@ -252,3 +252,21 @@ test('GPS006 - should not add separator to subscription and topic', async (t: Ex
   t.true(isTopicExisting);
   t.true(isSubcriptionExisting);
 });
+
+test('GPS007 - should add separator to topic name', async (t: ExecutionContext): Promise<void> => {
+  const topicName: string = 'topic_5';
+  const pubsub: GCPubSub = PubSubFactory.create({
+    transport: Transport.GOOGLE_PUBSUB,
+    options: {
+      projectId,
+      topicsPrefix: 'algoan',
+      topicsSeparator: '-',
+    },
+  });
+
+  await pubsub.listen(topicName);
+
+  const [isTopicExisting] = await pubsub.client.topic(`algoan-${topicName}`).exists();
+
+  t.true(isTopicExisting);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides option to customize topic and subscription separator, if topic or subscription prefix is provided

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some cases, using others programming languages and others libraries, it's necessary to maintain same pattern of {sub prefix}{sub separator}{topic name}. In this way you can customize each parts of subscription name's pattern.
Requested in #78 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
