### PR TITLE
[FIX] Remove huge originalMessage from log message

### DIFF
--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -127,12 +127,9 @@ export class GoogleCloudPubSub implements GCPubSub {
 
     subscription.on('message', (message: Message): void => {
       const extendedMessage: ExtendedMessage<T> = new ExtendedMessage<T>(message);
-      const logMessage: ExtendedMessage<T> = new ExtendedMessage<T>(message);
 
-      // eslint-disable-next-line
-      delete (logMessage as any).originalMessage;
       this.logger.debug(
-        logMessage,
+        { ...extendedMessage, originalMessage: undefined },
         `A message has been received for Subscription ${subscription.name} after ${
           message.received - message.publishTime.valueOf()
         } ms`,

--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -127,9 +127,12 @@ export class GoogleCloudPubSub implements GCPubSub {
 
     subscription.on('message', (message: Message): void => {
       const extendedMessage: ExtendedMessage<T> = new ExtendedMessage<T>(message);
+      const logMessage: ExtendedMessage<T> = new ExtendedMessage<T>(message);
 
+      // eslint-disable-next-line
+      delete (logMessage as any).originalMessage;
       this.logger.debug(
-        extendedMessage,
+        logMessage,
         `A message has been received for Subscription ${subscription.name} after ${
           message.received - message.publishTime.valueOf()
         } ms`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove `originalMessage` from the log message for `listen()` method of GoogleCloudPubSub class.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the logger logs the whole `extendedMessage` object that includes the huge property `originalMessage`, which makes the application not responding.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
