### PR TITLE
feat(googlecloudpubsub): add create options to the listen options

### DIFF
--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -1,5 +1,7 @@
 import {
   Attributes,
+  CreateSubscriptionResponse,
+  ExistsResponse,
   GetSubscriptionResponse,
   GetTopicOptions,
   GetTopicResponse,
@@ -233,9 +235,13 @@ export class GoogleCloudPubSub implements GCPubSub {
       return cachedSubscription;
     }
 
-    const [subscription]: GetSubscriptionResponse = await topic
-      .subscription(subscriptionName, options?.sub)
-      .get({ autoCreate: true, ...options?.get });
+    const sub: Subscription = topic.subscription(subscriptionName, options?.sub);
+    const [exists]: ExistsResponse = await sub.exists();
+
+    const [subscription]: GetSubscriptionResponse | CreateSubscriptionResponse = exists
+      ? await sub.get(options?.get)
+      : await sub.create(options?.create);
+
     this.subscriptions.set(subscriptionName, subscription);
 
     return subscription;

--- a/src/GoogleCloudPubSub/lib.ts
+++ b/src/GoogleCloudPubSub/lib.ts
@@ -1,4 +1,5 @@
 import {
+  CreateSubscriptionOptions,
   GetSubscriptionOptions,
   GetTopicOptions,
   PubSub as GPubSub,
@@ -60,6 +61,8 @@ export interface GCSubscriptionOptions {
   get?: Omit<GetSubscriptionOptions, 'autoCreate'>;
   /** Options applied to the subscription: https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#setOptions */
   sub?: SubscriptionOptions;
+  /** Options applied to the createSubscription  */
+  create?: CreateSubscriptionOptions;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Fixes #150 

Unfortunately, the Google PubSub NodeJS library does not allow to use [CreateSubscriptionOptions](https://googleapis.dev/nodejs/pubsub/latest/global.html#CreateSubscriptionRequest) with the `autoCreate` mode of the [`subscription.get`](https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#get) method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
