### PR TITLE
feat(googlepubsub): ability to change the default subscription name

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ If the chosen transport is Google Cloud PubSub, then `options` would be:
 
 - `autoAck`: Automatically ACK an event as soon as it is received (default to `true`)
 - `subscriptionOptions`: Options related to the created Subscription:
-  - `get`: Options applied to the getSubscription method (have a look at [Subscription options](https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#get))
+  - `name`: Custom name for the subscription. Default: `event` (also equal to the topic name)
+  - `get`: Options applied to the `getSubscription` method (have a look at [Subscription options](https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#get))
   - `sub`: Options applied to the subscription instance (see also [`setOptions` method](https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#setOptions))
+  - `create`: Options applied to the `createSubscription` method (have a look at [Create Subscription options](https://googleapis.dev/nodejs/pubsub/latest/Topic.html#createSubscription))
 - `topicOptions`: Options applied to the created topic (have a look at [Topic options](https://googleapis.dev/nodejs/pubsub/latest/Topic.html#get))
 
 ### `pubsub.emit(event, payload, opts)`

--- a/src/GoogleCloudPubSub/ExtendedMessage.ts
+++ b/src/GoogleCloudPubSub/ExtendedMessage.ts
@@ -53,7 +53,7 @@ export class ExtendedMessage<T> implements EmittedMessage<T> {
   public ack(): void {
     this.originalMessage.ack();
   }
-  
+
   /**
    * Shared modAck() method.
    * Use it if "autoAck" is disabled
@@ -61,7 +61,7 @@ export class ExtendedMessage<T> implements EmittedMessage<T> {
   public modAck(deadline: number): void {
     this.originalMessage.modAck(deadline);
   }
-  
+
   /**
    * Shared nack() method.
    * Use it if "autoAck" is disabled

--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -228,7 +228,7 @@ export class GoogleCloudPubSub implements GCPubSub {
     topic: Topic,
     options?: GCSubscriptionOptions,
   ): Promise<Subscription> {
-    const subscriptionName: string = this.getSubscriptionName(name);
+    const subscriptionName: string = options?.name ?? this.getSubscriptionName(name);
     const cachedSubscription: Subscription | undefined = this.subscriptions.get(subscriptionName);
 
     if (cachedSubscription !== undefined) {

--- a/src/GoogleCloudPubSub/lib.ts
+++ b/src/GoogleCloudPubSub/lib.ts
@@ -57,6 +57,8 @@ export interface GCListenOptions {
  * Mix Subscriptions Options interface
  */
 export interface GCSubscriptionOptions {
+  /** Subscription name. Default to topic name if not provided */
+  name?: string;
   /** Options applied to the getSubscription: https://googleapis.dev/nodejs/pubsub/latest/v1.SubscriberClient.html#getSubscription */
   get?: Omit<GetSubscriptionOptions, 'autoCreate'>;
   /** Options applied to the subscription: https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#setOptions */

--- a/test/GoogleCloudPubSub.test.ts
+++ b/test/GoogleCloudPubSub.test.ts
@@ -269,3 +269,33 @@ test('GPS007 - should add separator to topic name', async (t: ExecutionContext):
 
   t.true(isTopicExisting);
 });
+
+test('GPS008 - should create subscription with a different name', async (t: ExecutionContext): Promise<void> => {
+  const topicName: string = generateRandomTopicName();
+  const customSubscriptionName: string = 'custom_name';
+  const pubsub: GCPubSub = PubSubFactory.create({
+    transport: Transport.GOOGLE_PUBSUB,
+    options: {
+      projectId,
+      topicsPrefix: 'algoan',
+      topicsSeparator: '-',
+    },
+  });
+
+  await pubsub.listen(topicName, {
+    options: {
+      subscriptionOptions: {
+        name: customSubscriptionName,
+      },
+    },
+  });
+
+  const [isTopicExisting] = await pubsub.client.topic(`algoan-${topicName}`).exists();
+  const [isSubscriptionExisting] = await pubsub.client
+    .topic(`algoan-${topicName}`)
+    .subscription(customSubscriptionName)
+    .exists();
+
+  t.true(isTopicExisting);
+  t.true(isSubscriptionExisting);
+});


### PR DESCRIPTION
## Description

New feature resolving #132

## Motivation and Context

By default, the subscription has exactly the same name as the topic. Add a `name` option in the `listen` method in order to provide a custom name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
