### PR TITLE
[fix] replace misspelled variable in isErrorPayload function

### DIFF
--- a/src/EmittedMessage.ts
+++ b/src/EmittedMessage.ts
@@ -1,5 +1,5 @@
-import { ErrorPayload } from './GoogleCloudPubSub';
 import { Message } from '@google-cloud/pubsub';
+import { ErrorPayload } from './GoogleCloudPubSub';
 
 /**
  * Message emitted by the PubSub
@@ -47,4 +47,4 @@ export interface Metadata {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/tslint/config
 export const isPayloadError = <T>(payload: T | ErrorPayload): payload is ErrorPayload =>
-  'code' in payload && 'error' in payload;
+  'code' in payload && 'err' in payload;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
replace misspelled variable in function isErrorPayload : `error` => `err`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Function IsPayloadError always returns false because interface ErrorPayload do not have error but err field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
