### PR TITLE
[FIX] change onMessage parameter's type

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Get GCloud CLI to install pubsub emulator
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
     - name: Update GCloud Components
       run: gcloud components update --quiet
     - name: Install GCloud beta

--- a/src/PubSub.ts
+++ b/src/PubSub.ts
@@ -1,4 +1,5 @@
-import { EmittedMessage, Metadata } from './EmittedMessage';
+import { Metadata } from './EmittedMessage';
+import { ExtendedMessage } from './GoogleCloudPubSub';
 
 /**
  * PubSub generic interface
@@ -39,7 +40,7 @@ export interface ListenOptions<T, Options> {
   /** Error handler */
   onError?(error: Error): void;
   /** Message handler */
-  onMessage?(extendedMessage: EmittedMessage<T>): void;
+  onMessage?(extendedMessage: ExtendedMessage<T>): void;
   /** Options */
   options?: Options;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './PubSubFactory';
 export * from './PubSub';
 export * from './EmittedMessage';
 export * from './GoogleCloudPubSub/lib';
+export * from './GoogleCloudPubSub/ExtendedMessage';


### PR DESCRIPTION
## Description
This pull request aims to change the onMessage parameter's type from EmittedMessage to ExtendedMessage.

## Motivation and Context
I discovered this issue while implementing non automatic acknowledgment and flow control.
 
Currently the type of `extendedMessage` is `EmittedMessage<T>`. This interface declares some methods like `ack()` or `getOriginalMessage()` but does not implement them. The implementation part is done in the class `ExtendedMessage<T>`.
Thus when a Pub/Sub message is listened and handled by the `onMessage()` method, we are not able to use the methods of `extendedMessage`. 

To fix this I changed the parameter's type and added `ExtendedMessage<T>` to the exported files, so we are able to use it as type in external code.

Note: It is possible to bypass this problem using `any`, in my opinion it is a bad practice.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
