### PR TITLE
feat(topic): the autoCreate mode can now be manually disabled

### DIFF
--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -213,12 +213,13 @@ export class GoogleCloudPubSub implements GCPubSub {
   ): Promise<Topic> {
     const topicName: string = this.getTopicName(name);
     const cachedTopic: Topic | undefined = this.topics.get(topicName);
+    const topicOptions = { autoCreate: true, ...getTopicOptions };
 
     if (cachedTopic !== undefined) {
       return cachedTopic;
     }
 
-    const [topic]: GetTopicResponse = await this.client.topic(topicName).get({ autoCreate: true, ...getTopicOptions });
+    const [topic]: GetTopicResponse = await this.client.topic(topicName).get(topicOptions);
 
     if (publishOptions) {
       topic.setPublishOptions(publishOptions);

--- a/src/GoogleCloudPubSub/lib.ts
+++ b/src/GoogleCloudPubSub/lib.ts
@@ -51,7 +51,7 @@ export interface GCListenOptions {
   /** Google PubSub subscription options */
   subscriptionOptions?: GCSubscriptionOptions;
   /** Google PubSub topic options */
-  topicOptions?: Omit<GetTopicOptions, 'autoCreate'>;
+  topicOptions?: GetTopicOptions;
   /** Publishing message options */
   messageOptions?: Omit<MessageOptions, 'json' | 'data'>;
   /** Topic Publish options */
@@ -65,7 +65,7 @@ export interface GCSubscriptionOptions {
   /** Subscription name. Default to topic name if not provided */
   name?: string;
   /** Options applied to the getSubscription: https://googleapis.dev/nodejs/pubsub/latest/v1.SubscriberClient.html#getSubscription */
-  get?: Omit<GetSubscriptionOptions, 'autoCreate'>;
+  get?: GetSubscriptionOptions;
   /** Options applied to the subscription: https://googleapis.dev/nodejs/pubsub/latest/Subscription.html#setOptions */
   sub?: SubscriptionOptions;
   /** Options applied to the createSubscription  */


### PR DESCRIPTION
## Description

- `autoCreate` topic option can now be disabled

## Motivation and Context

If topics are created manually on the Google Cloud console, we do not necessarily want to auto-create topics to avoid mistakes. 

Related to https://github.com/algoan/nestjs-components/issues/664

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
