### PR TITLE
feat: allow configuring the dead-letter drain subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,28 @@ await pubsub.listen('my-special-sub', {
 });
 ```
 
+### Configuring the drain subscription (e.g. message retention)
+
+By default the drain subscription created on the dead-letter topic uses Google Cloud defaults — notably a **7-day** message retention. Provide `drainSubscriptionOptions` to override the `CreateSubscriptionOptions` used when the drain subscription is created (for example, to keep dead-lettered messages for the maximum of 31 days so there is more time to inspect and replay them).
+
+```typescript
+const pubsub: GCPubSub = PubSubFactory.create({
+  transport: Transport.GOOGLE_PUBSUB,
+  options: {
+    projectId: 'my-project',
+    deadLetterOptions: {
+      drainSubscriptionOptions: {
+        messageRetentionDuration: { seconds: 2678400 }, // 31 days (max)
+      },
+    },
+  },
+});
+
+await pubsub.listen('my-orders-sub');
+```
+
+Like the rest of the dead-letter setup, this is only applied when the drain subscription is **created** — an already-existing drain subscription is left untouched.
+
 ### No dead-letter topic
 
 If `deadLetterOptions` is not set, no dead-letter resources are created and no IAM calls are made — fully backward compatible.

--- a/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
+++ b/src/GoogleCloudPubSub/GoogleCloudPubSub.ts
@@ -368,7 +368,7 @@ export class GoogleCloudPubSub implements GCPubSub {
     const [exists] = await drainSub.exists();
 
     if (!exists) {
-      await createSubscriptionOrGet(drainSub, undefined, { autoCreate: false });
+      await createSubscriptionOrGet(drainSub, this.deadLetterOptions?.drainSubscriptionOptions, { autoCreate: false });
       this.logger.debug({ dltTopicName, drainSubName }, 'Created drain subscription on dead-letter topic');
     }
   }

--- a/src/GoogleCloudPubSub/lib.ts
+++ b/src/GoogleCloudPubSub/lib.ts
@@ -26,6 +26,14 @@ export interface DeadLetterOptions {
   deadLetterTopicName?: string;
   /** Maximum number of delivery attempts before forwarding to dead-letter topic (min: 5, max: 100) */
   maxDeliveryAttempts?: number;
+  /**
+   * Options applied when auto-creating the drain subscription on the dead-letter topic
+   * (e.g. `messageRetentionDuration`, `expirationPolicy`, `filter`).
+   * When omitted, the drain subscription is created with Google Cloud defaults
+   * (notably a 7-day message retention). Only applied at creation time — an
+   * already-existing drain subscription is left untouched.
+   */
+  drainSubscriptionOptions?: CreateSubscriptionOptions;
 }
 
 /**

--- a/test/GoogleCloudPubSub.test.ts
+++ b/test/GoogleCloudPubSub.test.ts
@@ -756,6 +756,43 @@ test('GPS014f - should apply maxDeliveryAttempts when configured', async (t: Exe
   }
 });
 
+test('GPS014h - should apply drainSubscriptionOptions to the auto-created dead-letter drain subscription', async (t: ExecutionContext): Promise<void> => {
+  const thirtyOneDaysInSeconds = 2678400;
+  const topicName: string = generateRandomTopicName();
+  const pubsub: GCPubSub = PubSubFactory.create({
+    transport: Transport.GOOGLE_PUBSUB,
+    options: {
+      projectId,
+      deadLetterOptions: {
+        drainSubscriptionOptions: {
+          messageRetentionDuration: { seconds: thirtyOneDaysInSeconds },
+        },
+      },
+    },
+  });
+
+  const authRequestStub = sinon.stub(pubsub.client.auth, 'request').resolves({
+    data: { projectNumber: '123456789' },
+  } as any);
+
+  try {
+    await pubsub.listen(topicName);
+
+    const sanitizedSubName = topicName.replace(/[^a-zA-Z0-9\-_.~]/g, '-');
+    const dltShortName = `${sanitizedSubName}-deadletter`;
+    const drainSub = pubsub.client.subscription(`${dltShortName}-sub`);
+    const [drainMetadata] = await drainSub.getMetadata();
+
+    t.is(
+      Number(drainMetadata.messageRetentionDuration?.seconds),
+      thirtyOneDaysInSeconds,
+      'should apply the configured messageRetentionDuration to the drain subscription',
+    );
+  } finally {
+    authRequestStub.restore();
+  }
+});
+
 test('GPS014g - should not duplicate IAM bindings when two subscriptions share the same dead-letter topic', async (t: ExecutionContext): Promise<void> => {
   const topicName1: string = generateRandomTopicName();
   const topicName2: string = generateRandomTopicName();


### PR DESCRIPTION
## What

Adds an optional `drainSubscriptionOptions` field to `DeadLetterOptions`. It is forwarded as `CreateSubscriptionOptions` when the library auto-creates the drain subscription on a dead-letter topic.

## Why

When `deadLetterOptions` is configured, the library creates a drain subscription on the dead-letter topic (so GCP doesn't discard dead-lettered messages). That drain subscription was always created with `undefined` options, so it inherited Google Cloud's **default 7-day message retention** with no way to change it.

The dead-letter subscription is exactly where you often want *longer* retention — it's where failed messages accumulate for inspection and replay. This change lets you configure it, e.g. to the 31-day maximum:

```typescript
const pubsub = PubSubFactory.create({
  transport: Transport.GOOGLE_PUBSUB,
  options: {
    projectId: 'my-project',
    deadLetterOptions: {
      drainSubscriptionOptions: {
        messageRetentionDuration: { seconds: 2678400 }, // 31 days (max)
      },
    },
  },
});
```

## Changes

- `src/GoogleCloudPubSub/lib.ts` — add `drainSubscriptionOptions?: CreateSubscriptionOptions` to `DeadLetterOptions` (documented via JSDoc).
- `src/GoogleCloudPubSub/GoogleCloudPubSub.ts` — pass `this.deadLetterOptions?.drainSubscriptionOptions` to `createSubscriptionOrGet` when creating the drain subscription (was `undefined`).
- `test/GoogleCloudPubSub.test.ts` — add `GPS014h`, asserting the configured `messageRetentionDuration` is applied to the drain subscription.
- `README.md` — document the new option under *Dead Letter Topics*.

## Compatibility

Fully backward compatible — when `drainSubscriptionOptions` is omitted, behaviour is unchanged. As with the rest of the dead-letter setup, options are applied only when the drain subscription is **created**; an already-existing drain subscription is left untouched.

## Notes

`npm run compile` and `npm run lint` pass locally. I couldn't run the full ava suite in my environment (the Pub/Sub emulator component wasn't available locally), so CI is the source of truth for the new test.